### PR TITLE
Creator POST Handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# Community Solid Server
+# Community Solid Server - MANDAT Fork
+
+## Features added for MANDAT
+- A handler for POST requests (creating a resource) that allows the creator of the resource to automatically have access to the resource by creating the corresponding ACL ([further explanation](/documentation/markdown/mandat/creator-post-handler.md))
+
+
+## Community Solid Server
 
 <img src="https://raw.githubusercontent.com/CommunitySolidServer/CommunitySolidServer/main/templates/images/solid.svg"
  alt="[Solid logo]" height="150" align="right"/>

--- a/config/default.json
+++ b/config/default.json
@@ -17,7 +17,7 @@
     "css:config/identity/pod/static.json",
     "css:config/ldp/authentication/dpop-bearer.json",
     "css:config/ldp/authorization/webacl.json",
-    "css:config/ldp/handler/default.json",
+    "css:config/ldp/handler/with-creator.json",
     "css:config/ldp/metadata-parser/default.json",
     "css:config/ldp/metadata-writer/default.json",
     "css:config/ldp/modes/default.json",

--- a/config/dynamic.json
+++ b/config/dynamic.json
@@ -17,7 +17,7 @@
     "css:config/identity/pod/dynamic.json",
     "css:config/ldp/authentication/dpop-bearer.json",
     "css:config/ldp/authorization/webacl.json",
-    "css:config/ldp/handler/default.json",
+    "css:config/ldp/handler/with-creator.json",
     "css:config/ldp/metadata-parser/default.json",
     "css:config/ldp/metadata-writer/default.json",
     "css:config/ldp/modes/default.json",

--- a/config/example-https-file.json
+++ b/config/example-https-file.json
@@ -17,7 +17,7 @@
     "css:config/identity/pod/static.json",
     "css:config/ldp/authentication/dpop-bearer.json",
     "css:config/ldp/authorization/webacl.json",
-    "css:config/ldp/handler/default.json",
+    "css:config/ldp/handler/with-creator.json",
     "css:config/ldp/metadata-parser/default.json",
     "css:config/ldp/metadata-writer/default.json",
     "css:config/ldp/modes/default.json",

--- a/config/file-acp.json
+++ b/config/file-acp.json
@@ -17,7 +17,7 @@
     "css:config/identity/pod/static.json",
     "css:config/ldp/authentication/dpop-bearer.json",
     "css:config/ldp/authorization/acp.json",
-    "css:config/ldp/handler/default.json",
+    "css:config/ldp/handler/with-creator.json",
     "css:config/ldp/metadata-parser/default.json",
     "css:config/ldp/metadata-writer/default.json",
     "css:config/ldp/modes/default.json",

--- a/config/file-root-pod.json
+++ b/config/file-root-pod.json
@@ -17,7 +17,7 @@
     "css:config/identity/pod/static.json",
     "css:config/ldp/authentication/dpop-bearer.json",
     "css:config/ldp/authorization/webacl.json",
-    "css:config/ldp/handler/default.json",
+    "css:config/ldp/handler/with-creator",
     "css:config/ldp/metadata-parser/default.json",
     "css:config/ldp/metadata-writer/default.json",
     "css:config/ldp/modes/default.json",

--- a/config/file-root.json
+++ b/config/file-root.json
@@ -17,7 +17,7 @@
     "css:config/identity/pod/static.json",
     "css:config/ldp/authentication/dpop-bearer.json",
     "css:config/ldp/authorization/webacl.json",
-    "css:config/ldp/handler/default.json",
+    "css:config/ldp/handler/with-creator",
     "css:config/ldp/metadata-parser/default.json",
     "css:config/ldp/metadata-writer/default.json",
     "css:config/ldp/modes/default.json",

--- a/config/file.json
+++ b/config/file.json
@@ -17,7 +17,7 @@
     "css:config/identity/pod/static.json",
     "css:config/ldp/authentication/dpop-bearer.json",
     "css:config/ldp/authorization/webacl.json",
-    "css:config/ldp/handler/default.json",
+    "css:config/ldp/handler/with-creator",
     "css:config/ldp/metadata-parser/default.json",
     "css:config/ldp/metadata-writer/default.json",
     "css:config/ldp/modes/default.json",

--- a/config/https-file-cli.json
+++ b/config/https-file-cli.json
@@ -17,7 +17,7 @@
     "css:config/identity/pod/static.json",
     "css:config/ldp/authentication/dpop-bearer.json",
     "css:config/ldp/authorization/webacl.json",
-    "css:config/ldp/handler/default.json",
+    "css:config/ldp/handler/with-creator",
     "css:config/ldp/metadata-parser/default.json",
     "css:config/ldp/metadata-writer/default.json",
     "css:config/ldp/modes/default.json",

--- a/config/ldp/handler/components/operation-handler-with-creator.json
+++ b/config/ldp/handler/components/operation-handler-with-creator.json
@@ -11,6 +11,21 @@
           "eTagHandler": { "@id": "urn:solid-server:default:ETagHandler" }
         },
         {
+          "@type": "CreatorPostOperationHandler",
+          "store": { "@id": "urn:solid-server:default:ResourceStore"  },
+          "creatorContainerNamesAndModes": [
+            ["demands", [
+              "Read",
+              "Append"
+            ]]
+          ],
+          "aclStrategy": { "@id": "urn:solid-server:default:AclStrategy" },
+          "credentialsExtractor": { "@id": "urn:solid-server:default:CredentialsExtractor" },
+          "resourceSet": { "@id": "urn:solid-server:default:CachedResourceSet" },
+          "identifierStrategy": { "@id": "urn:solid-server:default:IdentifierStrategy" },
+          "aclStore": { "@id": "urn:solid-server:default:ResourceStore" }
+        },
+        {
           "@type": "PostOperationHandler",
           "store": { "@id": "urn:solid-server:default:ResourceStore"  }
         },

--- a/config/ldp/handler/components/operation-handler.json
+++ b/config/ldp/handler/components/operation-handler.json
@@ -11,6 +11,13 @@
           "eTagHandler": { "@id": "urn:solid-server:default:ETagHandler" }
         },
         {
+          "@type": "CreatorPostOperationHandler",
+          "store": { "@id": "urn:solid-server:default:ResourceStore"  },
+          "creatorContainerNames": [ "demands" ],
+          "aclStrategy": { "@id": "urn:solid-server:default:AclStrategy" },
+          "credentialsExtractor": { "@id": "urn:solid-server:default:CredentialsExtractor" }
+        },
+        {
           "@type": "PostOperationHandler",
           "store": { "@id": "urn:solid-server:default:ResourceStore"  }
         },

--- a/config/ldp/handler/components/operation-handler.json
+++ b/config/ldp/handler/components/operation-handler.json
@@ -13,7 +13,12 @@
         {
           "@type": "CreatorPostOperationHandler",
           "store": { "@id": "urn:solid-server:default:ResourceStore"  },
-          "creatorContainerNames": [ "demands" ],
+          "creatorContainerNamesAndModes": [
+            ["demands", [
+              "Read",
+              "Append"
+            ]]
+          ],
           "aclStrategy": { "@id": "urn:solid-server:default:AclStrategy" },
           "credentialsExtractor": { "@id": "urn:solid-server:default:CredentialsExtractor" },
           "resourceSet": { "@id": "urn:solid-server:default:CachedResourceSet" },

--- a/config/ldp/handler/components/operation-handler.json
+++ b/config/ldp/handler/components/operation-handler.json
@@ -15,7 +15,10 @@
           "store": { "@id": "urn:solid-server:default:ResourceStore"  },
           "creatorContainerNames": [ "demands" ],
           "aclStrategy": { "@id": "urn:solid-server:default:AclStrategy" },
-          "credentialsExtractor": { "@id": "urn:solid-server:default:CredentialsExtractor" }
+          "credentialsExtractor": { "@id": "urn:solid-server:default:CredentialsExtractor" },
+          "resourceSet": { "@id": "urn:solid-server:default:CachedResourceSet" },
+          "identifierStrategy": { "@id": "urn:solid-server:default:IdentifierStrategy" },
+          "aclStore": { "@id": "urn:solid-server:default:ResourceStore" }
         },
         {
           "@type": "PostOperationHandler",

--- a/config/ldp/handler/with-creator.json
+++ b/config/ldp/handler/with-creator.json
@@ -1,0 +1,36 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "import": [
+    "css:config/ldp/handler/components/authorizer.json",
+    "css:config/ldp/handler/components/error-handler.json",
+    "css:config/ldp/handler/components/operation-handler-with-creator.json",
+    "css:config/ldp/handler/components/operation-metadata.json",
+    "css:config/ldp/handler/components/preferences.json",
+    "css:config/ldp/handler/components/request-parser.json",
+    "css:config/ldp/handler/components/response-writer.json"
+  ],
+  "@graph": [
+    {
+      "comment": "The main entry point into the main Solid behaviour.",
+      "@id": "urn:solid-server:default:LdpHandler",
+      "@type": "ParsingHttpHandler",
+      "args_requestParser": { "@id": "urn:solid-server:default:RequestParser" },
+      "args_errorHandler": { "@id": "urn:solid-server:default:ErrorHandler" },
+      "args_responseWriter": { "@id": "urn:solid-server:default:ResponseWriter" },
+      "args_operationHandler": {
+        "@type": "AuthorizingHttpHandler",
+        "args_credentialsExtractor": { "@id": "urn:solid-server:default:CredentialsExtractor" },
+        "args_modesExtractor": { "@id": "urn:solid-server:default:ModesExtractor" },
+        "args_permissionReader": { "@id": "urn:solid-server:default:PermissionReader" },
+        "args_authorizer": { "@id": "urn:solid-server:default:Authorizer" },
+        "args_operationHandler": {
+          "@type": "WacAllowHttpHandler",
+          "args_credentialsExtractor": { "@id": "urn:solid-server:default:CredentialsExtractor" },
+          "args_modesExtractor": { "@id": "urn:solid-server:default:ModesExtractor" },
+          "args_permissionReader": { "@id": "urn:solid-server:default:PermissionReader" },
+          "args_operationHandler": { "@id": "urn:solid-server:default:OperationHandler" }
+        }
+      }
+    }
+  ]
+}

--- a/config/memory-subdomains.json
+++ b/config/memory-subdomains.json
@@ -17,7 +17,7 @@
     "css:config/identity/pod/static.json",
     "css:config/ldp/authentication/dpop-bearer.json",
     "css:config/ldp/authorization/webacl.json",
-    "css:config/ldp/handler/default.json",
+    "css:config/ldp/handler/with-creator",
     "css:config/ldp/metadata-parser/default.json",
     "css:config/ldp/metadata-writer/default.json",
     "css:config/ldp/modes/default.json",

--- a/config/path-routing.json
+++ b/config/path-routing.json
@@ -17,7 +17,7 @@
     "css:config/identity/pod/static.json",
     "css:config/ldp/authentication/dpop-bearer.json",
     "css:config/ldp/authorization/webacl.json",
-    "css:config/ldp/handler/default.json",
+    "css:config/ldp/handler/with-creator",
     "css:config/ldp/metadata-parser/default.json",
     "css:config/ldp/metadata-writer/default.json",
     "css:config/ldp/modes/default.json",

--- a/config/quota-file.json
+++ b/config/quota-file.json
@@ -17,7 +17,7 @@
     "css:config/identity/pod/static.json",
     "css:config/ldp/authentication/dpop-bearer.json",
     "css:config/ldp/authorization/webacl.json",
-    "css:config/ldp/handler/default.json",
+    "css:config/ldp/handler/with-creator",
     "css:config/ldp/metadata-parser/default.json",
     "css:config/ldp/metadata-writer/default.json",
     "css:config/ldp/modes/default.json",

--- a/config/restrict-idp.json
+++ b/config/restrict-idp.json
@@ -17,7 +17,7 @@
     "css:config/identity/pod/static.json",
     "css:config/ldp/authentication/dpop-bearer.json",
     "css:config/ldp/authorization/webacl.json",
-    "css:config/ldp/handler/default.json",
+    "css:config/ldp/handler/with-creator",
     "css:config/ldp/metadata-parser/default.json",
     "css:config/ldp/metadata-writer/default.json",
     "css:config/ldp/modes/default.json",

--- a/config/sparql-endpoint-root.json
+++ b/config/sparql-endpoint-root.json
@@ -17,7 +17,7 @@
     "css:config/identity/pod/static.json",
     "css:config/ldp/authentication/dpop-bearer.json",
     "css:config/ldp/authorization/webacl.json",
-    "css:config/ldp/handler/default.json",
+    "css:config/ldp/handler/with-creator",
     "css:config/ldp/metadata-parser/default.json",
     "css:config/ldp/metadata-writer/default.json",
     "css:config/ldp/modes/default.json",

--- a/config/sparql-endpoint.json
+++ b/config/sparql-endpoint.json
@@ -17,7 +17,7 @@
     "css:config/identity/pod/static.json",
     "css:config/ldp/authentication/dpop-bearer.json",
     "css:config/ldp/authorization/webacl.json",
-    "css:config/ldp/handler/default.json",
+    "css:config/ldp/handler/with-creator",
     "css:config/ldp/metadata-parser/default.json",
     "css:config/ldp/metadata-writer/default.json",
     "css:config/ldp/modes/default.json",

--- a/config/sparql-file-storage.json
+++ b/config/sparql-file-storage.json
@@ -17,7 +17,7 @@
     "css:config/identity/pod/static.json",
     "css:config/ldp/authentication/dpop-bearer.json",
     "css:config/ldp/authorization/webacl.json",
-    "css:config/ldp/handler/default.json",
+    "css:config/ldp/handler/with-creator",
     "css:config/ldp/metadata-parser/default.json",
     "css:config/ldp/metadata-writer/default.json",
     "css:config/ldp/modes/default.json",

--- a/documentation/markdown/mandat/creator-post-handler.md
+++ b/documentation/markdown/mandat/creator-post-handler.md
@@ -1,0 +1,15 @@
+# Creator Post Handler
+A handler for POST requests (creating a resource) that allows the creator of the resource to automatically have access to the resource by creating the corresponding ACL
+
+## Config
+The handlers we are interested in are configured in [config/ldp/handlers/components/operation-handler.json](config/ldp/handler/components/operation-handler.json). We copied the file to [config/ldp/handlers/components/operation-handler-with-creator.json](config/ldp/handler/components/operation-handler-with-creator.json) and added a `CreatorPostOperationHandler` to the waterfall handler before the normal `PostOperationHandler`.
+
+The `CreatorPostOperationHandler` is configured as follows: Under `creatorContainerNamesAndModes` we can add an array of pairs where the first element of the pair is the name of the container to which the handler should apply and the second element of the pair is a list of ACL access modes that should be given to the creator of resources in this container.
+
+To use [config/ldp/handlers/components/operation-handler-with-creator.json](config/ldp/handler/components/operation-handler-with-creator.json) instead of [config/ldp/handlers/components/operation-handler.json](config/ldp/handler/components/operation-handler.json) we also created the config file [config/ldp/handler/with-creator.json](config/ldp/handler/with-creator.json) as alternative to [config/ldp/handler/default.json](config/ldp/handler/default.json) and added it to the provided global config files (e.g. [config/default.json](config/default.json), [config/file.json](config/file.json)).
+
+## Code
+All implementation has been done in the class [src/http/ldp/CreatorPostOperationHandler.ts](src/http/ldp/CreatorPostOperationHandler.ts).
+
+## Contributors
+[dschraudner](https://github.com/dschraudner), [se-schmid](https://github.com/se-schmid), [kaefer3000](https://github.com/kaefer3000)

--- a/documentation/markdown/mandat/creator-post-handler.md
+++ b/documentation/markdown/mandat/creator-post-handler.md
@@ -2,14 +2,14 @@
 A handler for POST requests (creating a resource) that allows the creator of the resource to automatically have access to the resource by creating the corresponding ACL
 
 ## Config
-The handlers we are interested in are configured in [config/ldp/handlers/components/operation-handler.json](config/ldp/handler/components/operation-handler.json). We copied the file to [config/ldp/handlers/components/operation-handler-with-creator.json](config/ldp/handler/components/operation-handler-with-creator.json) and added a `CreatorPostOperationHandler` to the waterfall handler before the normal `PostOperationHandler`.
+The handlers we are interested in are configured in [/config/ldp/handlers/components/operation-handler.json](../../../config/ldp/handler/components/operation-handler.json). We copied the file to [/config/ldp/handlers/components/operation-handler-with-creator.json](../../../config/ldp/handler/components/operation-handler-with-creator.json) and added a `CreatorPostOperationHandler` to the waterfall handler before the normal `PostOperationHandler`.
 
 The `CreatorPostOperationHandler` is configured as follows: Under `creatorContainerNamesAndModes` we can add an array of pairs where the first element of the pair is the name of the container to which the handler should apply and the second element of the pair is a list of ACL access modes that should be given to the creator of resources in this container.
 
-To use [config/ldp/handlers/components/operation-handler-with-creator.json](config/ldp/handler/components/operation-handler-with-creator.json) instead of [config/ldp/handlers/components/operation-handler.json](config/ldp/handler/components/operation-handler.json) we also created the config file [config/ldp/handler/with-creator.json](config/ldp/handler/with-creator.json) as alternative to [config/ldp/handler/default.json](config/ldp/handler/default.json) and added it to the provided global config files (e.g. [config/default.json](config/default.json), [config/file.json](config/file.json)).
+To use [/config/ldp/handlers/components/operation-handler-with-creator.json](../../../config/ldp/handler/components/operation-handler-with-creator.json) instead of [/config/ldp/handlers/components/operation-handler.json](../../../config/ldp/handler/components/operation-handler.json) we also created the config file [/config/ldp/handler/with-creator.json](../../../config/ldp/handler/with-creator.json) as alternative to [/config/ldp/handler/default.json](../../../config/ldp/handler/default.json) and added it to the provided global config files (e.g. [/config/default.json](../../../config/default.json), [/config/file.json](../../../config/file.json)).
 
 ## Code
-All implementation has been done in the class [src/http/ldp/CreatorPostOperationHandler.ts](src/http/ldp/CreatorPostOperationHandler.ts).
+All implementation has been done in the class [/src/http/ldp/CreatorPostOperationHandler.ts](../../../src/http/ldp/CreatorPostOperationHandler.ts).
 
 ## Contributors
 [dschraudner](https://github.com/dschraudner), [se-schmid](https://github.com/se-schmid), [kaefer3000](https://github.com/kaefer3000)

--- a/src/http/ldp/CreatorPostOperationHandler.ts
+++ b/src/http/ldp/CreatorPostOperationHandler.ts
@@ -1,0 +1,106 @@
+import type { Term } from 'rdf-js';
+import { getLoggerFor } from '../../logging/LogUtil';
+import type { ResourceStore } from '../../storage/ResourceStore';
+import { BadRequestHttpError } from '../../util/errors/BadRequestHttpError';
+import { InternalServerError } from '../../util/errors/InternalServerError';
+import { NotImplementedHttpError } from '../../util/errors/NotImplementedHttpError';
+import { find } from '../../util/IterableUtil';
+import { ACL, AS, LDP, RDF, SOLID_AS } from '../../util/Vocabularies';
+import { CreatedResponseDescription } from '../output/response/CreatedResponseDescription';
+import type { ResponseDescription } from '../output/response/ResponseDescription';
+import type { OperationHandlerInput } from './OperationHandler';
+import { OperationHandler } from './OperationHandler';
+import { randomInt } from 'crypto';
+import { AuxiliaryIdentifierStrategy } from '../../http/auxiliary/AuxiliaryIdentifierStrategy';
+import { isContainerIdentifier, trimTrailingSlashes } from '../../util/PathUtil';
+import { DataFactory, Store, Writer } from 'n3';
+import { RdfDatasetRepresentation } from '../representation/RdfDatasetRepresentation';
+import { CredentialsExtractor } from '../../authentication/CredentialsExtractor';
+import { OperationHttpHandlerInput } from '../../server/OperationHttpHandler';
+import { RepresentationMetadata } from '../../http/representation/RepresentationMetadata';
+import { BasicRepresentation } from '../../http/representation/BasicRepresentation';
+import { TEXT_TURTLE } from '../../util/ContentTypes';
+import { ResourceIdentifier } from '../..';
+
+/**
+ * Handles POST {@link Operation}s.
+ * Calls the addResource function from a {@link ResourceStore}.
+ */
+export class CreatorPostOperationHandler extends OperationHandler {
+  protected readonly logger = getLoggerFor(this);
+
+  private readonly store: ResourceStore;
+  private readonly creatorContainerNames: string[];
+  private readonly aclStrategy: AuxiliaryIdentifierStrategy;
+  private readonly credentialsExtractor: CredentialsExtractor;
+
+  public constructor(store: ResourceStore, creatorContainerNames: string[], aclStrategy: AuxiliaryIdentifierStrategy, credentialsExtractor: CredentialsExtractor) {
+    super();
+    this.store = store;
+    this.creatorContainerNames = creatorContainerNames;
+    this.aclStrategy = aclStrategy;
+    this.credentialsExtractor = credentialsExtractor;
+  }
+
+  public async canHandle({ operation }: OperationHandlerInput): Promise<void> {
+    if (operation.method !== 'POST') {
+      throw new NotImplementedHttpError('This handler only supports POST operations');
+    }
+    if (!isContainerIdentifier(operation.target)) {
+      throw new NotImplementedHttpError('This handler only handles POST requests to containers');
+    }
+    let targetPath = trimTrailingSlashes(operation.target.path);
+    let isCreatorContainer = this.creatorContainerNames.map(c => targetPath.endsWith(c)).reduce((a, b) => a || b);
+    if(!isCreatorContainer) {
+      throw new NotImplementedHttpError('This handler only handles creator containers specified in the config');
+    }
+  }
+
+  public async handle(input: OperationHttpHandlerInput): Promise<ResponseDescription> {
+    const type = new Set(input.operation.body.metadata.getAll(RDF.terms.type).map((term: Term): string => term.value));
+    const isContainerType = type.has(LDP.Container) || type.has(LDP.BasicContainer);
+    // Solid, §2.1: "A Solid server MUST reject PUT, POST and PATCH requests
+    // without the Content-Type header with a status code of 400."
+    // https://solid.github.io/specification/protocol#http-server
+    // An exception is made for LDP Containers as nothing is done with the body, so a Content-type is not required
+    if (!input.operation.body.metadata.contentType && !isContainerType) {
+      this.logger.warn('POST requests require the Content-Type header to be set');
+      throw new BadRequestHttpError('POST requests require the Content-Type header to be set');
+    }
+    const changes = await this.store.addResource(input.operation.target, input.operation.body, input.operation.conditions);
+    const createdIdentifier = find(changes.keys(), (identifier): boolean =>
+      Boolean(changes.get(identifier)?.has(SOLID_AS.terms.activity, AS.terms.Create)));
+    if (!createdIdentifier) {
+      throw new InternalServerError('Operation was successful but no created identifier was returned.');
+    }
+    const agentCredentials = await this.credentialsExtractor.handle(input.request);
+    if(agentCredentials.agent) {
+      const aclIdentifier = this.aclStrategy.getAuxiliaryIdentifier(createdIdentifier);
+      const serializedQuads = await this.writeQuads(createdIdentifier, agentCredentials.agent.webId);
+      const representation = new BasicRepresentation(serializedQuads, new RepresentationMetadata(aclIdentifier, TEXT_TURTLE));
+      await this.store.setRepresentation(aclIdentifier, representation);
+    }
+    return new CreatedResponseDescription(createdIdentifier);
+  }
+
+  private async writeQuads(createdIdentifier: ResourceIdentifier, agentWebId: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const authorization = DataFactory.blankNode();
+      const quads = [
+        DataFactory.quad(authorization, DataFactory.namedNode(RDF.type) , DataFactory.namedNode(ACL.Authorization)),
+        DataFactory.quad(authorization, DataFactory.namedNode(ACL.accessTo), DataFactory.namedNode(createdIdentifier.path)),
+        DataFactory.quad(authorization, DataFactory.namedNode(ACL.agent), DataFactory.namedNode(agentWebId)),
+        DataFactory.quad(authorization, DataFactory.namedNode(ACL.mode), DataFactory.namedNode(ACL.Read)),
+      ];
+      const writer = new Writer();
+      writer.addQuads(quads);
+      writer.end((err, result) => {
+        if(err) {
+          reject(err);
+        } else {
+          resolve(result);
+        }
+      })
+    });
+  }
+}

--- a/src/http/ldp/CreatorPostOperationHandler.ts
+++ b/src/http/ldp/CreatorPostOperationHandler.ts
@@ -10,17 +10,20 @@ import { CreatedResponseDescription } from '../output/response/CreatedResponseDe
 import type { ResponseDescription } from '../output/response/ResponseDescription';
 import type { OperationHandlerInput } from './OperationHandler';
 import { OperationHandler } from './OperationHandler';
-import { randomInt } from 'crypto';
 import { AuxiliaryIdentifierStrategy } from '../../http/auxiliary/AuxiliaryIdentifierStrategy';
 import { isContainerIdentifier, trimTrailingSlashes } from '../../util/PathUtil';
-import { DataFactory, Store, Writer } from 'n3';
-import { RdfDatasetRepresentation } from '../representation/RdfDatasetRepresentation';
+import { DataFactory, Quad, Store, Writer } from 'n3';
 import { CredentialsExtractor } from '../../authentication/CredentialsExtractor';
 import { OperationHttpHandlerInput } from '../../server/OperationHttpHandler';
 import { RepresentationMetadata } from '../../http/representation/RepresentationMetadata';
 import { BasicRepresentation } from '../../http/representation/BasicRepresentation';
-import { TEXT_TURTLE } from '../../util/ContentTypes';
-import { ResourceIdentifier } from '../..';
+import { INTERNAL_QUADS, TEXT_TURTLE } from '../../util/ContentTypes';
+import { PermissionReader } from '../../authorization/PermissionReader';
+import { ResourceIdentifier } from '../representation/ResourceIdentifier';
+import { ResourceSet } from '../../storage/ResourceSet';
+import { IdentifierStrategy } from '../../util/identifiers/IdentifierStrategy';
+import { ForbiddenHttpError } from '../../util/errors/ForbiddenHttpError';
+import { createErrorMessage, readableToQuads } from '../..';
 
 /**
  * Handles POST {@link Operation}s.
@@ -33,13 +36,27 @@ export class CreatorPostOperationHandler extends OperationHandler {
   private readonly creatorContainerNames: string[];
   private readonly aclStrategy: AuxiliaryIdentifierStrategy;
   private readonly credentialsExtractor: CredentialsExtractor;
+  private readonly resourceSet: ResourceSet;
+  private readonly identifierStrategy: IdentifierStrategy;
+  private readonly aclStore: ResourceStore;
 
-  public constructor(store: ResourceStore, creatorContainerNames: string[], aclStrategy: AuxiliaryIdentifierStrategy, credentialsExtractor: CredentialsExtractor) {
+  public constructor(
+    store: ResourceStore,
+    creatorContainerNames: string[],
+    aclStrategy: AuxiliaryIdentifierStrategy,
+    credentialsExtractor: CredentialsExtractor,
+    resourceSet: ResourceSet,
+    identifierStrategy: IdentifierStrategy,
+    aclStore: ResourceStore
+  ) {
     super();
     this.store = store;
     this.creatorContainerNames = creatorContainerNames;
     this.aclStrategy = aclStrategy;
     this.credentialsExtractor = credentialsExtractor;
+    this.resourceSet = resourceSet;
+    this.identifierStrategy = identifierStrategy;
+    this.aclStore = aclStore;
   }
 
   public async canHandle({ operation }: OperationHandlerInput): Promise<void> {
@@ -75,23 +92,53 @@ export class CreatorPostOperationHandler extends OperationHandler {
     }
     const agentCredentials = await this.credentialsExtractor.handle(input.request);
     if(agentCredentials.agent) {
+      const effectiveAclIdentifier = await this.getAclRecursive(createdIdentifier);
+
+      let contents: Store;
+      try {
+        const data = await this.aclStore.getRepresentation(effectiveAclIdentifier, { type: { [INTERNAL_QUADS]: 1 }});
+        contents = await readableToQuads(data.data);
+      } catch (error: unknown) {
+        // Something is wrong with the server if we can't read the resource
+        const message = `Error reading ACL resource ${effectiveAclIdentifier.path}: ${createErrorMessage(error)}`;
+        this.logger.error(message);
+        throw new InternalServerError(message, { cause: error });
+      }
+
+      const authorization = DataFactory.blankNode();
+      const quads = [
+        DataFactory.quad(authorization, DataFactory.namedNode(RDF.type) , DataFactory.namedNode(ACL.Authorization)),
+        DataFactory.quad(authorization, DataFactory.namedNode(ACL.accessTo), DataFactory.namedNode(createdIdentifier.path)),
+        DataFactory.quad(authorization, DataFactory.namedNode(ACL.agent), DataFactory.namedNode(agentCredentials.agent.webId)),
+        DataFactory.quad(authorization, DataFactory.namedNode(ACL.mode), DataFactory.namedNode(ACL.Read)),
+      ];
+
+      const subject = this.aclStrategy.getSubjectIdentifier(effectiveAclIdentifier);
+      //is Subject
+      if(createdIdentifier.path !== subject.path) {
+        const authorizations = contents.getSubjects(DataFactory.namedNode(ACL.default), null, null);
+        for(let a of authorizations) {
+          let aBlank = DataFactory.blankNode();
+          for(let q of contents.getQuads(a, null, null, null)) {
+            if(q.predicate.equals(DataFactory.namedNode(ACL.default))) {
+              quads.push(DataFactory.quad(aBlank, DataFactory.namedNode(ACL.accessTo), DataFactory.namedNode(createdIdentifier.path)));
+            } else if(!q.predicate.equals(DataFactory.namedNode(ACL.accessTo))) {
+              quads.push(DataFactory.quad(aBlank, q.predicate, q.object));
+            }
+          }
+        }
+      }
+
       const aclIdentifier = this.aclStrategy.getAuxiliaryIdentifier(createdIdentifier);
-      const serializedQuads = await this.writeQuads(createdIdentifier, agentCredentials.agent.webId);
+      const serializedQuads = await this.writeQuads(quads);
       const representation = new BasicRepresentation(serializedQuads, new RepresentationMetadata(aclIdentifier, TEXT_TURTLE));
       await this.store.setRepresentation(aclIdentifier, representation);
     }
     return new CreatedResponseDescription(createdIdentifier);
   }
 
-  private async writeQuads(createdIdentifier: ResourceIdentifier, agentWebId: string): Promise<string> {
+  private async writeQuads(quads: Quad[]): Promise<string> {
     return new Promise((resolve, reject) => {
-      const authorization = DataFactory.blankNode();
-      const quads = [
-        DataFactory.quad(authorization, DataFactory.namedNode(RDF.type) , DataFactory.namedNode(ACL.Authorization)),
-        DataFactory.quad(authorization, DataFactory.namedNode(ACL.accessTo), DataFactory.namedNode(createdIdentifier.path)),
-        DataFactory.quad(authorization, DataFactory.namedNode(ACL.agent), DataFactory.namedNode(agentWebId)),
-        DataFactory.quad(authorization, DataFactory.namedNode(ACL.mode), DataFactory.namedNode(ACL.Read)),
-      ];
       const writer = new Writer();
       writer.addQuads(quads);
       writer.end((err, result) => {
@@ -102,5 +149,39 @@ export class CreatorPostOperationHandler extends OperationHandler {
         }
       })
     });
+  }
+
+  private async getAclRecursive(identifier: ResourceIdentifier): Promise<ResourceIdentifier> {
+    // Obtain the direct ACL document for the resource, if it exists
+    this.logger.debug(`Trying to read the direct ACL document of ${identifier.path}`);
+
+    const acl = this.aclStrategy.getAuxiliaryIdentifier(identifier);
+    this.logger.debug(`Determining existence of  ${acl.path}`);
+    if (await this.resourceSet.hasResource(acl)) {
+      this.logger.info(`Found applicable ACL document ${acl.path}`);
+      return acl;
+    }
+    this.logger.debug(`No direct ACL document found for ${identifier.path}`);
+
+    // Find the applicable ACL document of the parent container
+    this.logger.debug(`Traversing to the parent of ${identifier.path}`);
+    if (this.identifierStrategy.isRootContainer(identifier)) {
+      this.logger.error(`No ACL document found for root container ${identifier.path}`);
+      // https://solidproject.org/TR/2021/wac-20210711#acl-resource-representation
+      // The root container MUST have an ACL resource with a representation.
+      throw new ForbiddenHttpError('No ACL document found for root container');
+    }
+    const parent = this.identifierStrategy.getParentContainer(identifier);
+    return this.getAclRecursive(parent);
+  }
+
+  private async filterStore(store: Store, target: string, directAcl: boolean): Promise<Store> {
+    // Find subjects that occur with a given predicate/object, and collect all their triples
+    const subjectData = new Store();
+    const subjects = store.getSubjects(directAcl ? ACL.terms.accessTo : ACL.terms.default, target, null);
+    for (const subject of subjects) {
+      subjectData.addQuads(store.getQuads(subject, null, null, null));
+    }
+    return subjectData;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,7 @@ export * from './http/ldp/HeadOperationHandler';
 export * from './http/ldp/OperationHandler';
 export * from './http/ldp/PatchOperationHandler';
 export * from './http/ldp/PostOperationHandler';
+export * from './http/ldp/CreatorPostOperationHandler';
 export * from './http/ldp/PutOperationHandler';
 
 // HTTP/Output/Error


### PR DESCRIPTION
A handler for POST requests (creating a resource) that allows the creator of the resource to automatically have access to the resource by creating the corresponding ACL.

Documentation can be found [here](https://github.com/mandat-project/CommunitySolidServer/blob/cfe49f50b1cce03ceb8ebf62ad4de3e287555a65/documentation/markdown/mandat/creator-post-handler.md).

@uvdsl Ping for deployment